### PR TITLE
Reference css files using relative paths.

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -110,9 +110,9 @@ app.registerExtension({
     async setup() {
         // Add the css call to the document
         create('link', null, document.getElementsByTagName('HEAD')[0], 
-            {'rel':'stylesheet', 'type':'text/css', 'href':`${BASE_PATH}/controller.css` } )
+            {'rel':'stylesheet', 'type':'text/css', 'href': new URL("./controller.css", import.meta.url).href } )
         create('link', null, document.getElementsByTagName('HEAD')[0], 
-            {'rel':'stylesheet', 'type':'text/css', 'href':`${BASE_PATH}/slider.css` } )
+            {'rel':'stylesheet', 'type':'text/css', 'href': new URL("./slider.css", import.meta.url).href} )
 
         // Allow our elements to do any setup they want
         try {


### PR DESCRIPTION
Hey Chris! We are launching the registry soon and realized the css files were not showing up for cg-controller. 

```
app.ts:1688 Error loading extension /extensions/comfyui-easy-use%401_2_5/easyuse.js TypeError: Failed to fetch dynamically imported module: http://127.0.0.1:8188/extensions/comfyui-easy-use%401_2_5/easyuse.js
```

This issue is that with the registry, we install nodes with a @version suffix, which means the BASE_PATH referenced here is incorrect. What do you think about using the relative import here?